### PR TITLE
Fixing typo "destory"

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { message } from '~'
+
 export default function () {
   return (
     <div
@@ -57,9 +58,9 @@ export default function () {
           type="button"
           className="btn btn-light"
           onClick={() => {
-            message.loading('Loading...', 4000).then(({ destory }) => {
+            message.loading('Loading...', 4000).then(({ destroy }) => {
               setTimeout(() => {
-                destory()
+                destroy()
                 message.success('成功', 4000)
               }, 2000)
             })

--- a/readme.md
+++ b/readme.md
@@ -22,9 +22,9 @@ import { message } from 'react-message-popup'
 message.success('成功', 4000)
 // etc.
 
-message.loading('Loading...', 4000).then(({ destory }) => {
+message.loading('Loading...', 4000).then(({ destroy }) => {
   setTimeout(() => {
-    destory()
+    destroy()
     message.success('成功', 4000)
   }, 2000)
 }
@@ -69,6 +69,6 @@ export interface MessageInstance {
 }
 
 export type MessageReturnType = {
-  destory(): boolean
+  destroy(): boolean
 }
 ```

--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -108,7 +108,7 @@ const message: MessageInstance = {}
           )
         }
         let isDestroyed = false
-        const destory = () => {
+        const destroy = () => {
           if (isDestroyed) {
             return false
           }
@@ -125,7 +125,7 @@ const message: MessageInstance = {}
         // because Infinity is 0 in timer
         if (reallyduration !== Infinity) {
           setTimeout(() => {
-            destory()
+            destroy()
             // 加 500ms 动画时间
           }, reallyduration + 500)
         }
@@ -135,7 +135,7 @@ const message: MessageInstance = {}
         })
 
         resolve({
-          destory,
+          destroy,
         })
       })
     })


### PR DESCRIPTION
I've changed the `destory` function to the correct grammatical form `destroy`.